### PR TITLE
fix: push to main branch instead of master in wiki sync workflow

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -58,4 +58,4 @@ jobs:
           fi
           git add .
           git commit -m "docs: sync wiki from repository docs"
-          git push origin master
+          git push origin main


### PR DESCRIPTION
The GitHub Actions workflow is currently pushing to `master` branch but the repository default branch is `main`. This fix updates the workflow to push to the correct branch.